### PR TITLE
Update requirements to include needed jarbas-utils module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jarbas_hive_mind>=0.10.1
+jarbas-utils>=0.6.5


### PR DESCRIPTION
Add jarbas-utils module into requirements file to be installed as a dependency as it is required for the cli to run.