### PR TITLE
fix(deps): require ovos-bus-client>=2.0.0a3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hivemind_bus_client>=0.4.4,<1.0.0
 HiveMind_presence>=0.0.2a2
-ovos-bus-client>=1.5.0,<2.0.0
+ovos-bus-client>=2.0.0a3
 ovos-spec-tools


### PR DESCRIPTION
Stable ovos-bus-client 1.5.0 bundles the colliding hivemind agent protocol; 2.x dropped it (#207). Require >=2.0.0a3. Part of the stack-wide 2.x migration.