### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,28 @@
 
 Terminal client for [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core).
 
-Connect to a HiveMind node from the command line, type utterances, and watch bus
-responses — no audio hardware required. This is the **simplest way to talk to a
-hive**: the "hello world" of HiveMind clients.
+Connect to a HiveMind node from the command line. Type an utterance and watch the
+response on the bus. No audio hardware is required. Among HiveMind clients, this
+one needs the least: only a keyboard.
 
 The curses UI shows a split-pane conversation view. `--no-curses` streams plain
-output, which is useful for scripting or SSH sessions with minimal terminal support.
+output. Use plain mode for scripting or for SSH sessions with minimal terminal
+support.
 
 ![HiveMind CLI terminal](./cli_terminal.png)
 
-## Where it fits — the satellite spectrum
+## Where it fits: the satellite spectrum
 
 | Client | Local processing | Remote processing |
 |---|---|---|
-| **HiveMind-cli** (this) | nothing | STT · TTS · intent · skills |
-| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | microphone · VAD | STT · TTS · intent · skills |
-| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic · VAD · wake-word | STT · TTS · intent · skills |
-| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic · VAD · wake-word · STT · TTS | intent · skills |
+| **HiveMind-cli** (this) | nothing | STT, TTS, intent, skills |
+| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | microphone, VAD | STT, TTS, intent, skills |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic, VAD, wake-word | STT, TTS, intent, skills |
+| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic, VAD, wake-word, STT, TTS | intent, skills |
 
-HiveMind-cli requires only a keyboard — no microphone, no speaker, no wake-word
-engine. Every other satellite adds layers on top of this foundation.
+HiveMind-cli requires only a keyboard. It has no microphone, no speaker, and no
+wake-word engine. Every other satellite in the table adds a layer of local
+processing on top of this one.
 
 ## Install
 
@@ -37,26 +39,26 @@ cd HiveMind-cli
 pip install -e .
 ```
 
-HiveMind CLI tracks the **HiveMind bus-client 2.x** stack (`ovos-bus-client>=2.0`).
-`pyproject.toml` is the single source of truth for dependencies — there is no
+HiveMind CLI tracks the HiveMind bus-client 2.x stack (`ovos-bus-client>=2.0`).
+`pyproject.toml` is the single source of truth for dependencies. There is no
 `requirements.txt`.
 
 ## Quickstart
 
-**1. Pair** — issue credentials on the server:
+**1. Pair.** Issue credentials on the server:
 
 ```bash
 hivemind-core add-client
 # → Access Key: <key>   Password: <password>
 ```
 
-**2. Connect** — start the terminal:
+**2. Connect.** Start the terminal:
 
 ```bash
 hivemind-cli --access-key <key> --password <password> --host wss://192.168.1.10
 ```
 
-**3. Type** — enter any utterance and press Enter. Responses appear in the
+**3. Type.** Enter an utterance and press Enter. The response appears in the
 conversation pane (`Mycroft > …`).
 
 ## CLI flags
@@ -67,50 +69,50 @@ conversation pane (`Mycroft > …`).
 | `--password` | `None` | Optional client password. |
 | `--host` | *(scan)* | HiveMind host URI, including protocol: `ws://…` or `wss://…`. |
 | `--port` | `5678` | WebSocket port. |
-| `--no-curses` | off | Disable the curses UI; use plain stdout/stdin instead. |
+| `--no-curses` | off | Disable the curses UI. Use plain stdout/stdin instead. |
 | `--self-signed` | off | Accept self-signed SSL certificates. |
 
-`--host` is technically optional: if omitted, the CLI scans the local network for a
-HiveMind node via UDP broadcast and asks before connecting.
+`--host` is optional. If you omit it, the CLI scans the local network for a
+HiveMind node over UDP broadcast and asks before connecting.
 
-The host **must** include the protocol prefix (`ws://` or `wss://`). The CLI exits
-with an error and a hint if it is missing.
+The host must include the protocol prefix (`ws://` or `wss://`). The CLI exits
+with an error and a hint if the prefix is missing.
 
 ## Modes
 
 ### Curses interface (default)
 
-A split-pane terminal UI with a scrollable message history and an `Input >` prompt.
-Responses appear as `Mycroft > <utterance>`. Requires a terminal that supports
-curses (most modern terminals do). Falls back automatically to plain mode if curses
-is unavailable at import time.
+A split-pane terminal UI with a scrollable message history and an `Input >`
+prompt. Responses appear as `Mycroft > <utterance>`. This mode needs a terminal
+that supports curses (most modern terminals do). If curses is unavailable at
+import time, the CLI falls back to plain mode.
 
 ### Plain mode (`--no-curses`)
 
-Line-by-line stdin/stdout. Responses are printed as ` Mycroft: <utterance>`.
-Suitable for SSH sessions with limited terminal support, piped input, or headless
+Line-by-line stdin/stdout. Responses print as ` Mycroft: <utterance>`. Use this
+mode for SSH sessions with limited terminal support, piped input, or headless
 scripting.
 
 ## Related
 
 | Project | Role |
 |---|---|
-| [HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) | The hive server — runs OVOS and manages satellites. |
-| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | Thinnest audio satellite (mic + VAD local). |
-| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | Voice relay (mic + VAD + wake-word local, STT/TTS remote). |
-| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | Full local stack (STT + TTS on-device). |
+| [HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core) | The HiveMind server. It runs OVOS and manages satellites. |
+| [hivemind-mic-satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite) | Thinnest audio satellite. Mic and VAD stay local. |
+| [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | Voice relay. Mic, VAD, and wake-word stay local; STT/TTS run remote. |
+| [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | Full local stack, including STT and TTS on-device. |
 
 ## Docs
 
 Full documentation lives in [`docs/`](docs/index.md). Contributors should read
-[`docs/development.md`](docs/development.md) for the dependency stack and how to run
-the end-to-end test suite.
+[`docs/development.md`](docs/development.md) for the dependency stack and how to
+run the end-to-end test suite.
 
 ## Testing
 
-The end-to-end suite boots a real `hivemind-core` master in-process (via
-[hivescope](https://github.com/JarbasHiveMind/hivescope)) and drives the real
-terminal client over a real bus — only stdin/stdout is mocked:
+The end-to-end suite boots a real `hivemind-core` master in-process, using
+[hivescope](https://github.com/JarbasHiveMind/hivescope), and drives the real
+terminal client over a real bus. Only stdin/stdout is mocked:
 
 ```bash
 pip install -e ".[e2e]"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,9 @@
 # Architecture
 
-This page is aimed at developers who want to understand the HiveMind client
-protocol by reading the simplest possible implementation. HiveMind CLI is that
-implementation — no audio pipeline, no wake-word engine, just the raw connection
-and message exchange.
+This page is for developers who want to understand the HiveMind client protocol
+by reading the simplest implementation. HiveMind CLI is that implementation. It
+has no audio pipeline and no wake-word engine, only the raw connection and
+message exchange.
 
 ---
 
@@ -66,20 +66,20 @@ self.bus.emit(Message(
 
 Key points:
 
-- **Message type** is `recognizer_loop:utterance` — the same message type that the
-  OVOS voice pipeline produces after STT. The hive receives this and processes it
-  identically to a spoken utterance. No special HiveMind-specific message type is
-  needed; the bridge translates the `destination: hive` context to route it
+- **Message type** is `recognizer_loop:utterance`, the same message type the OVOS
+  voice pipeline produces after STT. The hive receives this and processes it the
+  same way it processes a spoken utterance. No HiveMind-specific message type is
+  needed. The bridge translates the `destination: hive` context to route it
   correctly.
-- **`lang`** defaults to `"en-us"`. There is currently no CLI flag to override it;
-  the `JarbasCliTerminal.__init__` signature accepts a `lang` parameter for
+- **`lang`** defaults to `"en-us"`. No CLI flag overrides it. The
+  `JarbasCliTerminal.__init__` signature accepts a `lang` parameter for
   programmatic use.
 - **`destination: hive`** in the context tells `HiveMessageBusClient` to route the
   message upstream to the hive node rather than handling it locally.
 
 This is the minimal HiveMind client action: construct a `recognizer_loop:utterance`
 Message, set `destination: hive`, emit it. Every voice satellite does the same
-thing — just with audio-derived text instead of keyboard-derived text.
+thing, with audio-derived text instead of keyboard-derived text.
 
 ---
 
@@ -122,7 +122,7 @@ sets up three windows:
 |---|---|---|
 | `header_box` | top row | Displays the platform identifier string. |
 | `msg_box` | rows 1 … height-4 | Scrollable conversation history (`scrollok=True`). |
-| `input_box` | bottom 3 rows | `Input > ` prompt; `getstr()` for one line at a time. |
+| `input_box` | bottom 3 rows | `Input > ` prompt, using `getstr()` for one line at a time. |
 
 `curses.echo()` is set so typed characters appear on screen. After each `getstr()`
 call, the input is decoded from bytes to UTF-8, echoed into `msg_box` as
@@ -158,4 +158,7 @@ The core of a HiveMind client is five lines:
 5. Loop.
 
 Audio satellites add STT before step 4 and TTS after step 3. Everything else is
-the same. Reading this codebase first makes those satellites immediately legible.
+the same. Reading this codebase first makes those satellites easier to follow.
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Usage →](usage.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,9 +6,9 @@ All options are passed directly to `hivemind-cli`.
 
 ### `--access-key` *(required)*
 
-The client access key issued by `hivemind-core add-client`. Passed verbatim to
-`HiveMessageBusClient` as the identity credential. There is no default — the CLI
-refuses to start without it.
+The client access key issued by `hivemind-core add-client`. The CLI passes it
+verbatim to `HiveMessageBusClient` as the identity credential. There is no
+default. The CLI refuses to start without it.
 
 ### `--password`
 
@@ -28,8 +28,8 @@ ws://127.0.0.1           # loopback (local testing)
 The CLI validates the prefix at startup and exits with code `1` if it is missing.
 
 If `--host` is omitted entirely, the CLI prompts for a local-network scan using
-`hivemind_presence.LocalDiscovery` (UDP broadcast). Answering `y` starts the scan;
-each discovered node is printed and a connection is attempted.
+`hivemind_presence.LocalDiscovery` (UDP broadcast). Answering `y` starts the scan.
+The CLI prints each discovered node and attempts a connection.
 
 ### `--port`
 
@@ -78,11 +78,11 @@ hivemind-cli --access-key <key> --host wss://192.168.1.10 --self-signed
 
 | Scheme | When to use |
 |---|---|
-| `wss://` | Production, any deployment where traffic leaves the local machine. Certificate verification is on by default; add `--self-signed` for home CAs. |
+| `wss://` | Production, any deployment where traffic leaves the local machine. Certificate verification is on by default. Add `--self-signed` for home CAs. |
 | `ws://` | Local development only (`ws://127.0.0.1`). Never send credentials over unencrypted WebSocket on a shared network. |
 
-HiveMind-core listens on port `5678` for both schemes by default; the scheme choice
-is on the client side.
+HiveMind-core listens on port `5678` for both schemes by default. The client
+chooses the scheme.
 
 ---
 
@@ -105,3 +105,6 @@ hivemind-cli --access-key <key> --host ws://127.0.0.1 --no-curses < utterances.t
 ```
 
 The process exits only when stdin is closed (EOF), so pipe accordingly.
+
+---
+[← Getting started](getting-started.md) · [Home](index.md) · [Architecture →](architecture.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,14 +13,14 @@ cd HiveMind-cli
 pip install -e .
 ```
 
-`pyproject.toml` is the single source of truth for packaging — there is no
+`pyproject.toml` is the single source of truth for packaging. There is no
 `requirements.txt`, `setup.py`, or `setup.cfg`. Runtime dependencies live in
-`[project.dependencies]`; test dependencies live in the `[project.optional-dependencies]`
-extras described below.
+`[project.dependencies]`. Test dependencies live in the
+`[project.optional-dependencies]` extras described below.
 
 ---
 
-## Dependency stack — HiveMind bus 2.x
+## Dependency stack: HiveMind bus 2.x
 
 HiveMind CLI tracks the **HiveMind bus-client 2.x** stack. The pinned floors are
 prereleases, declared as minimum versions so a normal resolver picks them up with
@@ -82,7 +82,7 @@ pytest tests/e2e/test_cli_client.py
 
 ## How the end-to-end tests work
 
-The e2e tests are **real**, not mocked transports:
+The e2e tests use real transports, not mocks:
 
 1. [hivescope](https://github.com/JarbasHiveMind/hivescope) boots a real
    `hivemind-core` master **in-process** over a loopback WebSocket server
@@ -91,15 +91,15 @@ The e2e tests are **real**, not mocked transports:
 3. The real `JarbasCliTerminal` connects to that loopback URL through a real
    `HiveMessageBusClient`, completing the full handshake.
 4. The test drives the terminal:
-   - **stdin is mocked** — instead of a blocking `input()` call, the test calls the
+   - **stdin is mocked.** Instead of a blocking `input()` call, the test calls the
      same `say()` path the run loop uses per typed line.
-   - **stdout is mocked** — `terminal.speak` is replaced with a list `.append`, so
+   - **stdout is mocked.** `terminal.speak` is replaced with a list `.append`, so
      the test asserts on exactly what the user would have seen rendered, with no TTY.
-5. Assertions confirm that a typed utterance reaches the hub's OVOS agent bus, and
-   that a `speak` emitted by the hub is rendered back at the terminal.
+5. Assertions confirm that a typed utterance reaches the hive's OVOS agent bus, and
+   that a `speak` message emitted by the hive is rendered back at the terminal.
 
-There is no network beyond the localhost loopback socket, and no `importorskip` /
-`skipif` guards — the `[e2e]` extra installs the entire stack, so every test runs
+There is no network beyond the localhost loopback socket, and no `importorskip` or
+`skipif` guards. The `[e2e]` extra installs the entire stack, so every test runs
 for real on every CI run.
 
 ---
@@ -121,5 +121,8 @@ workflows (referenced `@dev`):
 | `repo_health` | Checks required files are present |
 | `release_workflow` / `publish_stable` | Alpha release on merge to `dev`, stable on merge to `master` |
 
-Versions bump automatically from conventional-commit prefixes — never hand-edit
+Versions bump automatically from conventional-commit prefixes. Never hand-edit
 `hivemind_cli_terminal/version.py`.
+
+---
+[← Usage](usage.md) · [Home](index.md) · [Troubleshooting →](troubleshooting.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,7 +32,7 @@ HiveMind-core and run:
 hivemind-core add-client
 ```
 
-The command prints an **Access Key** and a **Password**. Copy both — you will pass
+The command prints an **Access Key** and a **Password**. Copy both. You will pass
 them to the CLI.
 
 ---
@@ -91,7 +91,7 @@ You > what time is it
 Mycroft > It's 3:45 PM.
 ```
 
-That's it — you are talking to your hive.
+You are now talking to your hive.
 
 ---
 
@@ -107,9 +107,12 @@ Press **Ctrl-C** to disconnect and exit.
 2. Your typed line was wrapped in a `recognizer_loop:utterance` HiveMessage and
    sent to the hive.
 3. The hive ran intent matching and skill execution on the server side.
-4. The skill's `speak()` call produced a `speak` message that travelled back over
+4. The skill's `speak()` call produced a `speak` message that traveled back over
    the WebSocket.
 5. The CLI rendered it in the message pane.
 
 No audio ever left your machine. See [Architecture](architecture.md) for the full
 picture of what happens on the wire.
+
+---
+[Home](index.md) · [Configuration →](configuration.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
-# HiveMind CLI — Documentation
+# HiveMind CLI Documentation
 
 HiveMind CLI (`hivemind-cli`) is the text-only terminal client for
 [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core). It connects to a hive
-over WebSocket and lets you type utterances from the command line — no microphone,
-no speaker, no wake-word engine required.
+over WebSocket and lets you type utterances from the command line. No microphone,
+speaker, or wake-word engine is required.
 
-It is the **best first step** to understand HiveMind: the minimum surface needed to
-speak to a hive is one access key and a network connection. Every concept that
-matters (pairing, the wire protocol, session identity, how responses come back) is
-visible here before audio hardware is introduced.
+Start here to understand HiveMind. The minimum surface needed to speak to a hive
+is one access key and a network connection. Every concept that matters, including
+pairing, the wire protocol, session identity, and how responses come back, is
+visible here before audio hardware enters the picture.
 
 ## The satellite spectrum
 
@@ -19,10 +19,10 @@ visible here before audio hardware is introduced.
 | [HiveMind-voice-relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay) | mic · VAD · wake-word | STT · TTS · intent · skills |
 | [HiveMind-voice-sat](https://github.com/JarbasHiveMind/HiveMind-voice-sat) | mic · VAD · wake-word · STT · TTS | intent · skills |
 
-HiveMind-cli sits at the thin end of this spectrum: it is a pure keyboard interface.
-Audio satellites all build on top of the same connection and wire protocol; reading
-the CLI code is the clearest path to understanding how the client side of HiveMind
-works.
+HiveMind-cli sits at the thin end of this spectrum. It is a pure keyboard
+interface. Audio satellites all build on top of the same connection and wire
+protocol. Reading the CLI code is the clearest path to understanding how the
+client side of HiveMind works.
 
 ## Documentation pages
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ hivemind-cli --access-key <key> --host wss://192.168.1.10
 
 ---
 
-## Cannot connect — connection refused or timeout
+## Cannot connect: connection refused or timeout
 
 **Check the port.** HiveMind-core defaults to `5678`. If your server uses a
 different port, pass `--port`:
@@ -136,3 +136,6 @@ hivemind-cli --access-key <key> --host ws://192.168.1.10
 
 You answered `n` (or anything not starting with `y`) when asked whether to scan.
 Either re-run with `--host`, or run again and answer `y` to the scan prompt.
+
+---
+[← Development & Testing](development.md) · [Home](index.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,11 +12,11 @@ Connect to the hive and exercise the skill interactively:
 hivemind-cli --access-key <key> --password <pw> --host wss://192.168.1.10
 ```
 
-Type utterances that target the skill. The hive runs intent matching server-side;
-you see the response immediately without needing audio hardware on the client.
+Type utterances that target the skill. The hive runs intent matching server-side.
+You see the response immediately without needing audio hardware on the client.
 
-This is the fastest feedback loop for skill development: no microphone accuracy
-issues, no TTS delays, just raw intent + response.
+This gives a quick feedback loop for skill development, with no microphone
+accuracy issues and no TTS delay: only the intent match and the response.
 
 ---
 
@@ -106,19 +106,18 @@ subnet) and requires the hive node to have presence/discovery enabled.
 
 ---
 
-## Accessibility — keyboard-only voice assistant
+## Accessibility: a keyboard-only interface
 
-HiveMind CLI is the most accessible interface to a HiveMind hive:
+HiveMind CLI needs no audio hardware:
 
-- No audio hardware required.
 - Full keyboard operation.
 - Screen-reader compatible in `--no-curses` mode (plain stdout).
 - Works over SSH, so it runs on any device that can open a shell.
-- Latency is network + intent processing only — no STT/TTS round-trips.
+- Latency is network and intent processing only, with no STT/TTS round trip.
 
-For users who prefer text over audio, or in situations where audio is impractical
-(open offices, noisy environments, hearing impairments), the CLI provides a complete
-interface to all hive skills.
+For users who prefer text over audio, or in situations where audio is impractical,
+such as open offices, noisy environments, or hearing impairments, the CLI gives a
+full interface to all hive skills.
 
 To use it as a persistent assistant in a terminal multiplexer:
 
@@ -128,3 +127,6 @@ hivemind-cli --access-key <key> --password <pw> --host wss://192.168.1.10
 ```
 
 The session persists across disconnects as long as the multiplexer session is alive.
+
+---
+[← Architecture](architecture.md) · [Home](index.md) · [Development & Testing →](development.md)


### PR DESCRIPTION
Rewrites the README and the docs/ pages for clarity: shorter sentences, active voice, no marketing wording, and no em dashes or semicolons. Adds a navigation footer to each docs/ page pointing to its neighbors and the docs index. Every fact, code block, and link is unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation, quickstart steps, CLI behavior, operating modes, configuration, and troubleshooting guidance.
  * Improved explanations of architecture, accessibility, keyboard-only operation, satellite processing boundaries, and testing workflows.
  * Updated skill-testing guidance to highlight faster server-side feedback.
  * Added consistent navigation links across documentation pages.
  * Corrected wording, formatting, terminology, and minor spelling issues without changing commands or options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->